### PR TITLE
allow sudospawner-singleuser script to override launch procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ JupyterHub administrator to have ``sudo`` access to execute.
    has additional information about [creating a configuration file](http://jupyterhub.readthedocs.org/en/latest/getting-started.html#how-to-configure-jupyterhub),
    if needed, and [recommended file locations for configuration files](http://jupyterhub.readthedocs.org/en/latest/getting-started.html#file-locations).
 
+## Custom singleuser launch command
+
+
+In order to limit what permissions the use of sudospawner grants the Hub,
+when a single-user server is launched
+the executable spawned is hardcoded as `dirname(sudospawner)/jupyterhub-singleuser`.
+This requires the `sudospawner` executable to be in the same directory as the `jupyterhub-singleuser` command.
+It is **very important** that users cannot modify the `bin/` directory containing `sudospawner`,
+otherwise they can modify what `sudospawner` actually enables JupyterHub to do.
+
+You may want to initialize user environment variables before launching the server, or do other initialization.
+If you install a script called `sudospawner-singleuser` next to `sudospawner`,
+this will be used instead of the direct `jupyterhub-singleuser` command.
+
+For example:
+
+```bash
+#!/bin/bash -l
+export FOO=BAR
+
+# this is how most sudospawner-singleuser scripts should end:
+exec "$(dirname "$0")/jupyterhub-singleuser" $@
+```
+
 ## Example
 
 The [Dockerfile](https://github.com/jupyter/sudospawner/blob/master/Dockerfile) in this repo contains an example configuration for setting up a JupyterHub system,


### PR DESCRIPTION
Normally not present, this script allows admins to install a custom entry point for singleuser servers, without requiring override of jupyterhub-singleuser or allowing the Hub user to modify what is launched via environment variables.

closes #25

cc @parente does this sound good to you? It should mean just installing one script in a particular location, rather than the shuffling around you have been doing.