### PR TITLE
The OS import was missing

### DIFF
--- a/sudospawner/spawner.py
+++ b/sudospawner/spawner.py
@@ -9,6 +9,7 @@ This spawns a mediator process with sudo, which then takes actions on behalf of 
 
 import json
 import sys
+import os
 
 from tornado import gen
 from tornado.ioloop import IOLoop


### PR DESCRIPTION
The kill function uses the os package. Without this import, it fails.