### PR TITLE
Remove deprecated backward-compat for jupyterhub < 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes in sudospawner
 
+## 0.5
+
+- Remove deprecated code for supporting JupyterHub < 0.7.
+  JupyterHub ≥ 0.7 is required.
+
 ## 0.4
 
 ### 0.4.1

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup_args = dict(
 # setuptools requirements
 if 'setuptools' in sys.modules:
     setup_args['install_requires'] = install_requires = [
-        'jupyterhub>=0.4',
+        'jupyterhub>=0.7',
         'notebook',
     ]
 

--- a/sudospawner/spawner.py
+++ b/sudospawner/spawner.py
@@ -82,10 +82,6 @@ class SudoSpawner(LocalProcessSpawner):
     @gen.coroutine
     def start(self):
         self.port = random_port()
-        # pre-0.7 JupyterHub, store ip/port in user.server:
-        self.user.server.ip = self.ip
-        self.user.server.port = self.port
-        self.db.commit()
 
         # only args, not the base command
         reply = yield self.do(action='spawn', args=self.get_args(), env=self.get_env())


### PR DESCRIPTION
jupyterhub 0.7 or greater is required from now on.