### PR TITLE
updates for 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5
 
+### 0.5.1
+
+- Fix bug preventing JupyterHub 0.8 from connecting to Spawners with default `ip`.
+
+### 0.5.0
 - Remove deprecated code for supporting JupyterHub < 0.7.
   JupyterHub ≥ 0.7 is required.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 # example showing sudo config
-# docker run -it -p 9000:8000 jupyter/jupyterhub-sudo
+# docker run -it -p 9000:8000 jupyterhub/jupyterhub-sudo
 
-FROM jupyter/jupyterhub
+FROM jupyterhub/jupyterhub:0.8.0
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
+RUN apt-get -y update \
+    && apt-get -y install sudo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 # fix permissions on sudo executable (how did this get messed up?)
 RUN chmod 4755 /usr/bin/sudo
+
+RUN python3 -m pip install notebook
 
 # add the rhea user, who will run the server
 # she needs to be in the shadow group in order to access the PAM service
@@ -25,9 +31,10 @@ RUN chmod o-rwx /home/*
 
 ADD . /srv/sudospawn
 WORKDIR /srv/sudospawn
-RUN pip3 install .
+RUN python3 -m pip install .
 
 # make the working dir owned by rhea, so she can create the state database
 RUN chown rhea .
 
 USER rhea
+ADD examples/jupyterhub_config.py ./jupyterhub_config.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
 include README.md
-include Dockerfile
 
 graft examples
 

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,5 +1,9 @@
 # example showing sudo config
-# docker run -it -p 9000:8000 jupyterhub/jupyterhub-sudo
+# build from root with:
+#    docker build -t jupyterhub-sudo -f examples/Dockerfile .
+# run with:
+#    docker run -it -p 9000:8000 jupyterhub-sudo
+# visit http://127.0.0.1:9000 and login with username: io, password: io
 
 FROM jupyterhub/jupyterhub:0.8.0
 

--- a/examples/jupyterhub_config.py
+++ b/examples/jupyterhub_config.py
@@ -4,3 +4,6 @@ c = get_config()
 
 # use the sudo spawner
 c.JupyterHub.spawner_class = 'sudospawner.SudoSpawner'
+
+c.SudoSpawner.debug_mediator = True
+c.JupyterHub.log_level = 10

--- a/examples/sudoers
+++ b/examples/sudoers
@@ -3,7 +3,7 @@ Runas_Alias JUPYTER_USERS = io, europa, ganymede, callisto, rhea
 
 # the command(s) jupyterhub can run on behalf of the above users without needing a password
 # this command handles the signalling of spawning servers
-Cmnd_Alias SPAWNER_CMD = /usr/local/bin/sudospawner
+Cmnd_Alias SPAWNER_CMD = /opt/conda/bin/sudospawner
 
 # actually give hub user permission to run the above command on behalf
 # of the above users without a password

--- a/sudospawner/spawner.py
+++ b/sudospawner/spawner.py
@@ -90,7 +90,7 @@ class SudoSpawner(LocalProcessSpawner):
         self.pid = reply['pid']
         print(self.ip)
         # 0.7 expects ip, port to be returned
-        return (self.ip, self.port)
+        return (self.ip or '127.0.0.1', self.port)
 
     @gen.coroutine
     def _signal(self, sig):

--- a/sudospawner/spawner.py
+++ b/sudospawner/spawner.py
@@ -46,7 +46,7 @@ class SudoSpawner(LocalProcessSpawner):
                 # If we do that, will get huge double-prefix messages:
                 # [I date JupyterHub] [W date SingleUser] msg...
                 sys.stderr.write(line.decode('utf8', 'replace'))
-    
+
     @gen.coroutine
     def do(self, action, **kwargs):
         """Instruct the mediator process to take a given action"""
@@ -56,13 +56,14 @@ class SudoSpawner(LocalProcessSpawner):
         cmd.append(self.sudospawner_path)
         if self.debug_mediator:
             cmd.append('--logging=debug')
-        
+
+        self.log.debug("Spawning %s", cmd)
         p = Subprocess(cmd, stdin=Subprocess.STREAM, stdout=Subprocess.STREAM, stderr=Subprocess.STREAM)
         stderr_future = self.relog_stderr(p.stderr)
         # hand the stderr future to the IOLoop so it isn't orphaned,
         # even though we aren't going to wait for it unless there's an error
         IOLoop.current().add_callback(lambda : stderr_future)
-        
+
         yield p.stdin.write(json.dumps(kwargs).encode('utf8'))
         p.stdin.close()
         data = yield p.stdout.read_until_close()

--- a/sudospawner/spawner.py
+++ b/sudospawner/spawner.py
@@ -8,6 +8,7 @@ This spawns a mediator process with sudo, which then takes actions on behalf of 
 
 
 import json
+import shutil
 import sys
 import os
 
@@ -22,8 +23,8 @@ from jupyterhub.spawner import LocalProcessSpawner
 from jupyterhub.utils import random_port
 
 class SudoSpawner(LocalProcessSpawner):
-    
-    sudospawner_path = Unicode('sudospawner', config=True,
+
+    sudospawner_path = Unicode(shutil.which('sudospawner') or 'sudospawner', config=True,
         help="Path to sudospawner script"
     )
     sudo_args = List(['-nH'], config=True,
@@ -32,7 +33,7 @@ class SudoSpawner(LocalProcessSpawner):
     debug_mediator = Bool(False, config=True,
         help="Extra log output from the mediator process for debugging",
     )
-    
+
     @gen.coroutine
     def relog_stderr(self, stderr):
         while not stderr.closed():
@@ -86,6 +87,7 @@ class SudoSpawner(LocalProcessSpawner):
         # only args, not the base command
         reply = yield self.do(action='spawn', args=self.get_args(), env=self.get_env())
         self.pid = reply['pid']
+        print(self.ip)
         # 0.7 expects ip, port to be returned
         return (self.ip, self.port)
 


### PR DESCRIPTION
The main change is the small fix in e2dc1d5, ensuring that the Hub connects to localhost instead of the current hostname.
Only the default behavior is affected.
This can be worked around with the current stable version of sudospawner by adding the configuration:

    c.Spawner.ip = '127.0.0.1'

The rest is updating the Dockerfile example for 0.8.

closes #44