### PR TITLE
Python 3.9-3.13 support with GitHub Actions fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 # Always build and verify our release process, but then also conditionally
 # upload to PyPI if a git tag triggered the workflow.
-#
 name: Release
 
 on:
@@ -10,12 +9,12 @@ on:
 
 jobs:
   build-verify-upload-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.9"
 
       - name: install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,11 @@ jobs:
           python -m pip install --pre -r test-requirements.txt -e .
       - name: Run pytest
         run: |
-          pytest -v --color=yes --cov=sudospawner sudospawner/tests
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+          if [[ "${{ matrix.python }}" == "3.12" ]]; then
+            # TODO: there is some issue with Python 3.12 and coverage that causes a test suite failure
+            pytest -v --color=yes sudospawner/tests
+          else
+            pytest -v --color=yes --cov=sudospawner sudospawner/tests
+          fi
       - name: Submit codecov report
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,3 @@
-# This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
-#
 name: Test
 
 # Trigger the workflow's on all PRs but only on pushed tags or commits to
@@ -13,30 +10,29 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     strategy:
       # Keep running even if one variation of the job fail
       fail-fast: false
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v2
-      # NOTE: actions/setup-python@v2 make use of a cache within the GitHub base
+      - uses: actions/checkout@v4
+      # NOTE: actions/setup-python@v5 make use of a cache within the GitHub base
       #       environment and setup in a fraction of a second.
       - name: Install Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip
-          pip install --pre -r test-requirements.txt -e .
+          python -m pip install --upgrade pip
+          python -m pip install --pre -r test-requirements.txt -e .
       - name: Run pytest
         run: |
           pytest -v --color=yes --cov=sudospawner sudospawner/tests
       - name: Submit codecov report
-        run: |
-          codecov
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Run pytest
         run: |
           pytest -v --color=yes --cov=sudospawner sudospawner/tests
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
       - name: Submit codecov report
         uses: codecov/codecov-action@v4

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ import os
 import sys
 
 v = sys.version_info
-if v[:2] < (3, 3):
-    error = "ERROR: Jupyter Hub requires Python version 3.3 or above."
+if v[:2] < (3, 9):
+    error = "ERROR: Jupyter Hub requires Python version 3.9 or above."
     print(error, file=sys.stderr)
     sys.exit(1)
 

--- a/sudospawner/mediator.py
+++ b/sudospawner/mediator.py
@@ -85,7 +85,7 @@ def spawn(singleuser, args, env):
     and prohibit PYTHONPATH from env for basic protections.
     """
     cmd = [singleuser] + args
-    cmd_s = ' '.join(shlex.quote(s) for s in cmd)
+    cmd_s = shlex.join(cmd)
     app_log.info("Spawning %s", cmd_s)
     if 'PYTHONPATH' in env:
         app_log.warn("PYTHONPATH env not allowed for security reasons")

--- a/sudospawner/spawner.py
+++ b/sudospawner/spawner.py
@@ -70,7 +70,7 @@ class SudoSpawner(LocalProcessSpawner):
             self.mediator_log_level = 'DEBUG'
             warnings.warn("debug_mediator is deprecated in favor of mediator_log_level", DeprecationWarning)
         if self.mediator_log_level:
-            cmd.append('--logging={}'.format(self.mediator_log_level))
+            cmd.append(f'--logging={self.mediator_log_level}')
 
         self.log.debug("Spawning %s", cmd)
         p = Subprocess(cmd, stdin=Subprocess.STREAM, stdout=Subprocess.STREAM, stderr=Subprocess.STREAM, preexec_fn=self.make_preexec_fn())

--- a/sudospawner/spawner.py
+++ b/sudospawner/spawner.py
@@ -103,7 +103,6 @@ class SudoSpawner(LocalProcessSpawner):
         # only args, not the base command
         reply = yield self.do(action='spawn', args=self.get_args(), env=self.get_env())
         self.pid = reply['pid']
-        print(self.ip)
         # 0.7 expects ip, port to be returned
         return (self.ip or '127.0.0.1', self.port)
 

--- a/sudospawner/tests/mockserver.py
+++ b/sudospawner/tests/mockserver.py
@@ -12,6 +12,7 @@ Handlers and their purpose include:
 Copied from JupyterHub test suite.
 
 """
+
 import argparse
 import json
 import os
@@ -46,8 +47,8 @@ def main(args):
     )
 
     server = httpserver.HTTPServer(app)
-    server.listen(args.port, '127.0.0.1')
-    log.app_log.info("Starting mock server on 127.0.0.1:%i" % args.port)
+    server.listen(args.port, "127.0.0.1")
+    log.app_log.info(f"Starting mock server on 127.0.0.1:{args.port}")
     loop = ioloop.IOLoop.current()
     # stop after 60 seconds
     # so we don't leave orphaned processes lying about
@@ -61,6 +62,6 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--port", type=int)
+    parser.add_argument("--port", type=int, required=True)
     args, extra = parser.parse_known_args()
     main(args)

--- a/sudospawner/tests/test_sudospawner.py
+++ b/sudospawner/tests/test_sudospawner.py
@@ -83,7 +83,7 @@ def test_spawn(user):
     pid = spawner.pid
     status = yield spawner.poll()
     assert status is None
-    url = "http://{}:{}".format(ip, port)
+    url = f"http://{ip}:{port}"
     r = requests.get(url)
     r.raise_for_status()
     yield spawner.stop()
@@ -119,7 +119,7 @@ def test_env(user):
     status = yield spawner.poll()
     time.sleep(1)
     assert status is None
-    url = "http://{}:{}/env".format(ip, port)
+    url = f"http://{ip}:{port}/env"
     r = requests.get(url)
     yield spawner.stop()
     r.raise_for_status()

--- a/sudospawner/tests/test_sudospawner.py
+++ b/sudospawner/tests/test_sudospawner.py
@@ -36,9 +36,7 @@ def user():
 _mock_server_sh = """
 #!/bin/sh
 exec "{}" -m sudospawner.tests.mockserver "$@"
-""".format(
-    sys.executable
-).lstrip()
+""".format(sys.executable).lstrip()
 
 
 @pytest.fixture(autouse=True)
@@ -72,8 +70,19 @@ class MockSudoSpawner(SudoSpawner):
         return env
 
     def do(self, *args, **kwargs):
-        kwargs['_skip_sudo'] = True
+        kwargs["_skip_sudo"] = True
         return super().do(*args, **kwargs)
+
+    def get_args(self):
+        # Per super().get_args():
+        # .. versionchanged:: 2.0
+        #     Prior to 2.0, JupyterHub passed some options such as ip, port,
+        #     and default_url to the command-line. JupyterHub 2.0 no longer builds
+        #     any CLI args other than `Spawner.cmd` and `Spawner.args`. All values
+        #     that come from jupyterhub itself will be passed via environment
+        #     variables.
+        # mock sudospawner needs --port and will fail without it.
+        return [f"--port={self.port}"]
 
 
 @pytest.mark.gen_test

--- a/sudospawner/tests/test_sudospawner.py
+++ b/sudospawner/tests/test_sudospawner.py
@@ -14,12 +14,10 @@ from sudospawner import SudoSpawner
 @pytest.fixture(scope="module")
 def io_loop(request):
     """Same as pytest-tornado.io_loop, but re-scoped to module-level"""
-    io_loop = ioloop.IOLoop()
-    io_loop.make_current()
+    io_loop = ioloop.IOLoop.current()
 
     def _close():
-        io_loop.clear_current()
-        io_loop.close(all_fds=True)
+        io_loop.close()
 
     request.addfinalizer(_close)
     return io_loop
@@ -33,10 +31,11 @@ def user():
     return user
 
 
-_mock_server_sh = """
+_mock_server_sh = f"""
 #!/bin/sh
-exec "{}" -m sudospawner.tests.mockserver "$@"
-""".format(sys.executable).lstrip()
+echo "Running mock server:"
+exec "{sys.executable}" -m sudospawner.tests.mockserver "$@"
+""".lstrip()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Changes

* Updated GitHub Actions workflows to test on 3.9-3.13
* Changed minimum required Python version to 3.9 in `setup.py` (per [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) this is still conservative; I assume that's followed here?)
* Replaced deprecated `pipes.quote` with `shlex.join`
* A bit of modernization with f-strings as this targets 3.9+. 
* Fixed the test spawner to ensure compatibility with JupyterHub 2.0+.

## Notes

There was a bit of a hiccup - for some reason coverage on Python 3.12 (only) breaks `test_spawn`. Without coverage, all versions tested pass.

I didn't manage to get to the root of that issue, so I simply avoided coverage for Python 3.12 in the CI.