### PR TITLE
Expose __version__ and version_info directly

### DIFF
--- a/sudospawner/__init__.py
+++ b/sudospawner/__init__.py
@@ -1,1 +1,2 @@
 from .spawner import SudoSpawner
+from .version import __version__, version_info

--- a/sudospawner/version.py
+++ b/sudospawner/version.py
@@ -1,1 +1,7 @@
+# __version__ should be updated using tbump, based on configuration in
+# pyproject.toml, according to instructions in RELEASE.md.
+#
 __version__ = "0.6.0.dev"
+
+# version_info looks like (1, 2, 3, "dev") if __version__ is 1.2.3.dev
+version_info = tuple(int(p) if p.isdigit() else p for p in __version__.split("."))


### PR DESCRIPTION
I became very appreciative of these fields when working to dynamically patch security vulnerabilities.

We are exposing such fields in jupyterhub and oauthenticator for example, as well as in the jupyterhub-python-repo-template.